### PR TITLE
Update runningSessions.tsx

### DIFF
--- a/packages/apputils/src/runningSessions.tsx
+++ b/packages/apputils/src/runningSessions.tsx
@@ -128,6 +128,7 @@ export class RunningSessions extends VDomRenderer<RunningSessions.Model> {
       this.model.terminals,
       this.model!.sessions
     );
+    this.title.title = this.title.caption; // Set the tooltip text to the same as the caption
     return (
       <RunningSessionsComponent
         sessions={this.model.sessions}


### PR DESCRIPTION
Addition of a line of code to ensure that the tooltip text is the same as the caption text.

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Running sessions status bar title does not work #14082


## Code changes

this.title.caption = this._trans.__(
  '%1 Terminals, %2 Kernel sessions',
  this.model.terminals,
  this.model.sessions
);
this.title.title = this.title.caption; // Set the tooltip text to the same as the caption



