### PR TITLE
Update connection.ts

### DIFF
--- a/packages/lsp/src/connection.ts
+++ b/packages/lsp/src/connection.ts
@@ -268,9 +268,15 @@ export class LSPConnection extends LspWsConnection implements ILSPConnection {
     if (this.isDisposed) {
       return;
     }
-    Object.values(this.serverRequests).forEach(request =>
-      request.clearHandler()
+
+    /**
+     * Check if serverRequests is defined before accessing values
+     */
+    if (this.serverRequests) {
+      Object.values(this.serverRequests).forEach(request =>
+        request.clearHandler()
     );
+    }
     this.close();
     super.dispose();
   }


### PR DESCRIPTION

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

Incorrect disposal of LSP connection due to access to undefined serverRequests #16185

## Code changes

<!-- Describe the code changes and how they address the issue. -->

dispose(): void {
  if (this.isDisposed) {
    return;
  }

  // Check if serverRequests is defined before accessing its values
  if (this.serverRequests) {
    Object.values(this.serverRequests).forEach(request =>
      request.clearHandler()
    );
  }

  // Other disposal logic here
}


Modified the dispose() method in connection.ts to include a check for this.serverRequests before accessing its values during disposal.

Added a conditional check to ensure that connections are disposed only if serverRequests is defined, preventing the TypeError on kernel switching.


