### PR TITLE
Update connection.ts

### DIFF
--- a/packages/lsp/src/connection.ts
+++ b/packages/lsp/src/connection.ts
@@ -262,12 +262,24 @@ export class LSPConnection extends LspWsConnection implements ILSPConnection {
   }
 
   /**
-   * Dispose the connection.
+ * Dispose the connection.
+ */
+dispose(): void {
+  if (this.isDisposed) {
+    return;
+  }
+
+  /**
+   * Check if serverRequests is defined before accessing values
    */
-  dispose(): void {
-    if (this.isDisposed) {
-      return;
-    }
+  if (this.serverRequests) {
+    Object.values(this.serverRequests).forEach(request =>
+      request.clearHandler()
+    );
+  }
+  this.close();
+  super.dispose();
+}
 
     /**
      * Check if serverRequests is defined before accessing values


### PR DESCRIPTION
This modification ensures that the clearHandler method is only called on serverRequests if it is defined, preventing the TypeError related to accessing properties of undefined or null objects.

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/main/CONTRIBUTING.md
-->

## References

 Incorrect disposal of LSP connection due to access to undefined serverRequests #16185:

## Code changes

This modification should ensure that the clearHandler method is only called on serverRequests if it is defined, preventing the TypeError related to accessing properties of undefined or null objects. 


